### PR TITLE
Generalize test for table builder output size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target
+Cargo.lock
+kcov-out

--- a/examples/rw_sstable/src/main.rs
+++ b/examples/rw_sstable/src/main.rs
@@ -47,7 +47,8 @@ fn read_table(p: &Path) -> Result<sstable::Table> {
 }
 
 fn lookup(t: &sstable::Table, key: &str) -> Result<Option<String>> {
-    Ok(t.get(key.as_bytes())?.map(|v| unsafe { String::from_utf8_unchecked(v) }))
+    Ok(t.get(key.as_bytes())?
+        .map(|v| unsafe { String::from_utf8_unchecked(v) }))
 }
 
 fn main() {

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -239,8 +239,8 @@ impl<T> Cache<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::LRUList;
+    use super::*;
 
     fn make_key(a: u8, b: u8, c: u8) -> CacheKey {
         [a, b, c, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -85,32 +85,54 @@ mod tests {
 
     #[test]
     fn test_cmp_defaultcmp_shortest_sep() {
-        assert_eq!(DefaultCmp.find_shortest_sep("abcd".as_bytes(), "abcf".as_bytes()),
-                   "abce".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("abc".as_bytes(), "acd".as_bytes()),
-                   "abc\0".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("abcdefghi".as_bytes(), "abcffghi".as_bytes()),
-                   "abce".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("a".as_bytes(), "a".as_bytes()),
-                   "a".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("a".as_bytes(), "b".as_bytes()),
-                   "a\0".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("abc".as_bytes(), "zzz".as_bytes()),
-                   "b".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("yyy".as_bytes(), "z".as_bytes()),
-                   "yyy\0".as_bytes());
-        assert_eq!(DefaultCmp.find_shortest_sep("".as_bytes(), "".as_bytes()),
-                   "".as_bytes());
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("abcd".as_bytes(), "abcf".as_bytes()),
+            "abce".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("abc".as_bytes(), "acd".as_bytes()),
+            "abc\0".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("abcdefghi".as_bytes(), "abcffghi".as_bytes()),
+            "abce".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("a".as_bytes(), "a".as_bytes()),
+            "a".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("a".as_bytes(), "b".as_bytes()),
+            "a\0".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("abc".as_bytes(), "zzz".as_bytes()),
+            "b".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("yyy".as_bytes(), "z".as_bytes()),
+            "yyy\0".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_shortest_sep("".as_bytes(), "".as_bytes()),
+            "".as_bytes()
+        );
     }
 
     #[test]
     fn test_cmp_defaultcmp_short_succ() {
-        assert_eq!(DefaultCmp.find_short_succ("abcd".as_bytes()),
-                   "b".as_bytes());
-        assert_eq!(DefaultCmp.find_short_succ("zzzz".as_bytes()),
-                   "{".as_bytes());
+        assert_eq!(
+            DefaultCmp.find_short_succ("abcd".as_bytes()),
+            "b".as_bytes()
+        );
+        assert_eq!(
+            DefaultCmp.find_short_succ("zzzz".as_bytes()),
+            "{".as_bytes()
+        );
         assert_eq!(DefaultCmp.find_short_succ(&[]), &[0xff]);
-        assert_eq!(DefaultCmp.find_short_succ(&[0xff, 0xff, 0xff]),
-                   &[0xff, 0xff, 0xff, 0xff]);
+        assert_eq!(
+            DefaultCmp.find_short_succ(&[0xff, 0xff, 0xff]),
+            &[0xff, 0xff, 0xff, 0xff]
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -106,4 +106,3 @@ pub type Result<T> = result::Result<T, Status>;
 pub fn err<T>(code: StatusCode, msg: &str) -> Result<T> {
     Err(Status::new(code, msg))
 }
-

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -246,7 +246,8 @@ mod tests {
             "xxx111xxx222".as_bytes(),
             "ab00cd00ab".as_bytes(),
             "908070605040302010".as_bytes(),
-        ].iter()
+        ]
+        .iter()
         {
             offs.push(concat.len());
             concat.extend_from_slice(d);

--- a/src/filter_block.rs
+++ b/src/filter_block.rs
@@ -164,10 +164,10 @@ impl FilterBlockReader {
 
 #[cfg(test)]
 mod tests {
-    use filter::BloomPolicy;
-    use super::*;
-    use super::FILTER_BASE_LOG2;
     use super::get_filter_index;
+    use super::FILTER_BASE_LOG2;
+    use super::*;
+    use filter::BloomPolicy;
 
     #[test]
     fn test_filter_index() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ mod table_reader;
 pub use cmp::{Cmp, DefaultCmp};
 pub use error::{Result, Status, StatusCode};
 pub use options::{CompressionType, Options};
-pub use types::{current_key_val, SSIterator};
 pub use table_builder::TableBuilder;
 pub use table_reader::{Table, TableIterator};
+pub use types::{current_key_val, SSIterator};
 
 #[cfg(test)]
 mod test_util;

--- a/src/table_block.rs
+++ b/src/table_block.rs
@@ -36,7 +36,11 @@ pub fn read_filter_block(
 /// Reads a table block from a random-access source.
 /// A table block consists of [bytes..., compress (1B), checksum (4B)]; the handle only refers to
 /// the location and length of [bytes...].
-pub fn read_table_block(opt: Options, f: &dyn RandomAccess, location: &BlockHandle) -> Result<Block> {
+pub fn read_table_block(
+    opt: Options,
+    f: &dyn RandomAccess,
+    location: &BlockHandle,
+) -> Result<Block> {
     // The block is denoted by offset and length in BlockHandle. A block in an encoded
     // table is followed by 1B compression type and 4B checksum.
     // The checksum refers to the compressed contents.

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -125,9 +125,21 @@ impl<Dst: Write> TableBuilder<Dst> {
     #[allow(unused)]
     fn size_estimate(&self) -> usize {
         let mut size = 0;
-        size += self.data_block.as_ref().map(|b| b.size_estimate()).unwrap_or(0);
-        size += self.index_block.as_ref().map(|b| b.size_estimate()).unwrap_or(0);
-        size += self.filter_block.as_ref().map(|b| b.size_estimate()).unwrap_or(0);
+        size += self
+            .data_block
+            .as_ref()
+            .map(|b| b.size_estimate())
+            .unwrap_or(0);
+        size += self
+            .index_block
+            .as_ref()
+            .map(|b| b.size_estimate())
+            .unwrap_or(0);
+        size += self
+            .filter_block
+            .as_ref()
+            .map(|b| b.size_estimate())
+            .unwrap_or(0);
         size += self.offset;
         size += FULL_FOOTER_LENGTH;
         size
@@ -217,7 +229,8 @@ impl<Dst: Write> TableBuilder<Dst> {
         // If there's a pending data block, write it
         if self.data_block.as_ref().unwrap().entries() > 0 {
             // Find a key reliably past the last key
-            let key_past_last = self.opt
+            let key_past_last = self
+                .opt
                 .cmp
                 .find_short_succ(self.data_block.as_ref().unwrap().last_key());
             self.write_data_block(&key_past_last)?;

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -309,7 +309,10 @@ mod tests {
         assert!(b.filter_block.is_some());
 
         let actual = b.finish().unwrap();
-        assert_eq!(223, actual);
+        // Ensure that something has been written
+        assert!(!d.is_empty());
+        // The returned length should be the same as the data size
+        assert_eq!(d.len(), actual);
     }
 
     #[test]

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -668,5 +668,4 @@ mod tests {
             panic!("Should have hit 5th record in table!");
         }
     }
-
 }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,5 @@
-use types::{current_key_val, SSIterator};
 use cmp::{Cmp, DefaultCmp};
+use types::{current_key_val, SSIterator};
 
 use std::cmp::Ordering;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,8 +2,8 @@
 
 use error::Result;
 
-use std::fs::File;
 use std::cell::RefCell;
+use std::fs::File;
 use std::os::unix::fs::FileExt;
 use std::rc::Rc;
 


### PR DESCRIPTION
When using compression the actually written size might change depending on the current dependencies. The test now checks that any data has been written at all and that the value returned by `finish()` matches the actual size of the data buffer.