### PR TITLE
Implement RandomAccess for File on Windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 dist: bionic
 sudo: false
 addons:

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,10 @@ use error::Result;
 
 use std::cell::RefCell;
 use std::fs::File;
+#[cfg(unix)]
 use std::os::unix::fs::FileExt;
+#[cfg(windows)]
+use std::os::windows::fs::FileExt;
 use std::rc::Rc;
 
 pub trait RandomAccess {
@@ -31,9 +34,17 @@ impl RandomAccess for BufferBackedFile {
     }
 }
 
+#[cfg(unix)]
 impl RandomAccess for File {
     fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize> {
         Ok((self as &dyn FileExt).read_at(dst, off as u64)?)
+    }
+}
+
+#[cfg(windows)]
+impl RandomAccess for File {
+    fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize> {
+        Ok((self as &dyn FileExt).seek_read(dst, off as u64)?)
     }
 }
 


### PR DESCRIPTION
sstable did not compile for any non-Unix platform because
std::os::unix::fs::FileExt was used unconditionally.
This commit adds support for Windows by using the `seek_read` function
instead of `read_at` (https://doc.rust-lang.org/stable/std/os/windows/fs/trait.FileExt.html#tymethod.seek_read).
As far as I can tell, the RandomAccess interface does not give any
guarantees on how the cursor position is handled and thus it should not be
problematic that reading from the file at random positions also changes
the cursor.

In addition, it is now possible to use sstable on other non-Unix
platforms by implementing RandomAccess for a wrapper struct of File
using any platform-specific function.

The Travis CI configuration has been updated to include Windows in the tests, too.