### PR TITLE
Make Table implement Send+Sync

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::options::Options;
 use crate::types::SSIterator;
@@ -32,7 +32,7 @@ pub type BlockContents = Vec<u8>;
 /// N_RESTARTS contains the number of restarts.
 #[derive(Clone)]
 pub struct Block {
-    block: Rc<BlockContents>,
+    block: Arc<BlockContents>,
     opt: Options,
 }
 
@@ -59,14 +59,14 @@ impl Block {
         }
     }
 
-    pub fn contents(&self) -> Rc<BlockContents> {
+    pub fn contents(&self) -> Arc<BlockContents> {
         self.block.clone()
     }
 
     pub fn new(opt: Options, contents: BlockContents) -> Block {
         assert!(contents.len() > 4);
         Block {
-            block: Rc::new(contents),
+            block: Arc::new(contents),
             opt: opt,
         }
     }
@@ -76,8 +76,7 @@ impl Block {
 /// lifetime, as it uses a refcounted block underneath.
 pub struct BlockIter {
     /// The underlying block contents.
-    /// TODO: Maybe (probably...) this needs an Arc.
-    block: Rc<BlockContents>,
+    block: Arc<BlockContents>,
     opt: Options,
     /// offset of restarts area within the block.
     restarts_off: usize,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -152,7 +152,6 @@ impl<T> LRUList<T> {
     }
 }
 
-
 pub type CacheKey = [u8; 16];
 pub type CacheID = u64;
 type CacheEntry<T> = (T, LRUHandle<CacheKey>);
@@ -237,7 +236,6 @@ impl<T> Cache<T> {
         }
     }
 }
-
 
 // The compiler does not automatically derive Send and Sync for Cache because it contains
 // raw pointers.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -152,6 +152,7 @@ impl<T> LRUList<T> {
     }
 }
 
+
 pub type CacheKey = [u8; 16];
 pub type CacheID = u64;
 type CacheEntry<T> = (T, LRUHandle<CacheKey>);
@@ -236,6 +237,16 @@ impl<T> Cache<T> {
         }
     }
 }
+
+
+// The compiler does not automatically derive Send and Sync for Cache because it contains
+// raw pointers.
+// These raw pointers are only pointing to the elements hold in the same cache and insertion
+// clones the values. It is therefore safe to implement Send for Cache.
+// Since all functions that access these raw pointers are mutable member functions, it is also safe to implement Sync
+// (Sync is defined as "if &T is Send-able")
+unsafe impl<T: Send> Send for Cache<T> {}
+unsafe impl<T: Sync> Sync for Cache<T> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 /// Comparator trait, supporting types that can be nested (i.e., add additional functionality on
 /// top of an inner comparator)
-pub trait Cmp {
+pub trait Cmp : Sync +  Send {
     /// Compare to byte strings, bytewise.
     fn cmp(&self, _: &[u8], _: &[u8]) -> Ordering;
 

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 /// Comparator trait, supporting types that can be nested (i.e., add additional functionality on
 /// top of an inner comparator)
-pub trait Cmp : Sync +  Send {
+pub trait Cmp: Sync + Send {
     /// Compare to byte strings, bytewise.
     fn cmp(&self, _: &[u8], _: &[u8]) -> Ordering;
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,11 +1,11 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use integer_encoding::FixedInt;
 
 /// Encapsulates a filter algorithm allowing to search for keys more efficiently.
 /// Usually, policies are used as a BoxedFilterPolicy (see below), so they
 /// can be easily cloned and nested.
-pub trait FilterPolicy {
+pub trait FilterPolicy: Send + Sync {
     /// Returns a string identifying this policy.
     fn name(&self) -> &'static str;
     /// Create a filter matching the given keys. Keys are given as a long byte array that is
@@ -17,7 +17,7 @@ pub trait FilterPolicy {
 
 /// A boxed and refcounted filter policy (reference-counted because a Box with unsized content
 /// couldn't be cloned otherwise)
-pub type BoxedFilterPolicy = Rc<Box<dyn FilterPolicy>>;
+pub type BoxedFilterPolicy = Arc<Box<dyn FilterPolicy>>;
 
 /// Used for tables that don't have filter blocks but need a type parameter.
 #[derive(Clone)]

--- a/src/filter_block.rs
+++ b/src/filter_block.rs
@@ -1,7 +1,7 @@
 use crate::block::BlockContents;
 use crate::filter::BoxedFilterPolicy;
 
-use std::rc::Rc;
+use std::sync::Arc;
 
 use integer_encoding::FixedInt;
 
@@ -108,7 +108,7 @@ impl FilterBlockBuilder {
 #[derive(Clone)]
 pub struct FilterBlockReader {
     policy: BoxedFilterPolicy,
-    block: Rc<BlockContents>,
+    block: Arc<BlockContents>,
 
     offsets_offset: usize,
     filter_base_lg2: u32,
@@ -116,10 +116,10 @@ pub struct FilterBlockReader {
 
 impl FilterBlockReader {
     pub fn new_owned(pol: BoxedFilterPolicy, data: Vec<u8>) -> FilterBlockReader {
-        FilterBlockReader::new(pol, Rc::new(data))
+        FilterBlockReader::new(pol, Arc::new(data))
     }
 
-    pub fn new(pol: BoxedFilterPolicy, data: Rc<Vec<u8>>) -> FilterBlockReader {
+    pub fn new(pol: BoxedFilterPolicy, data: Arc<Vec<u8>>) -> FilterBlockReader {
         assert!(data.len() >= 5);
 
         let fbase = data[data.len() - 1] as u32;
@@ -186,7 +186,7 @@ mod tests {
 
     fn produce_filter_block() -> Vec<u8> {
         let keys = get_keys();
-        let mut bld = FilterBlockBuilder::new(Rc::new(Box::new(BloomPolicy::new(32))));
+        let mut bld = FilterBlockBuilder::new(Arc::new(Box::new(BloomPolicy::new(32))));
 
         bld.start_block(0);
 
@@ -223,7 +223,7 @@ mod tests {
     #[test]
     fn test_filter_block_build_read() {
         let result = produce_filter_block();
-        let reader = FilterBlockReader::new_owned(Rc::new(Box::new(BloomPolicy::new(32))), result);
+        let reader = FilterBlockReader::new_owned(Arc::new(Box::new(BloomPolicy::new(32))), result);
 
         assert_eq!(
             reader.offset_of(get_filter_index(5121, FILTER_BASE_LOG2)),

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,7 +5,7 @@ use crate::filter;
 use crate::types::{share, Shared};
 
 use std::default::Default;
-use std::rc::Rc;
+use std::sync::Arc;
 
 const KB: usize = 1 << 10;
 const MB: usize = KB * KB;
@@ -33,7 +33,7 @@ pub fn int_to_compressiontype(i: u32) -> Option<CompressionType> {
 /// self-explanatory; the defaults are defined in the `Default` implementation.
 #[derive(Clone)]
 pub struct Options {
-    pub cmp: Rc<Box<dyn Cmp>>,
+    pub cmp: Arc<Box<dyn Cmp>>,
     pub write_buffer_size: usize,
     pub block_cache: Shared<Cache<Block>>,
     pub block_size: usize,
@@ -45,14 +45,14 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Options {
         Options {
-            cmp: Rc::new(Box::new(DefaultCmp)),
+            cmp: Arc::new(Box::new(DefaultCmp)),
             write_buffer_size: WRITE_BUFFER_SIZE,
             // 2000 elements by default
             block_cache: share(Cache::new(BLOCK_CACHE_CAPACITY / BLOCK_MAX_SIZE)),
             block_size: BLOCK_MAX_SIZE,
             block_restart_interval: 16,
             compression_type: CompressionType::CompressionNone,
-            filter_policy: Rc::new(Box::new(filter::BloomPolicy::new(DEFAULT_BITS_PER_KEY))),
+            filter_policy: Arc::new(Box::new(filter::BloomPolicy::new(DEFAULT_BITS_PER_KEY))),
         }
     }
 }

--- a/src/table_builder.rs
+++ b/src/table_builder.rs
@@ -9,7 +9,7 @@ use crate::types::mask_crc;
 
 use std::cmp::Ordering;
 use std::io::Write;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crc::crc32;
 use crc::Hasher32;
@@ -95,7 +95,7 @@ pub struct TableBuilder<Dst: Write> {
 
 impl<Dst: Write> TableBuilder<Dst> {
     pub fn new_no_filter(mut opt: Options, dst: Dst) -> TableBuilder<Dst> {
-        opt.filter_policy = Rc::new(Box::new(NoFilterPolicy::new()));
+        opt.filter_policy = Arc::new(Box::new(NoFilterPolicy::new()));
         TableBuilder::new(opt, dst)
     }
 }

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -11,7 +11,7 @@ use crate::types::{current_key_val, RandomAccess, SSIterator};
 use std::cmp::Ordering;
 use std::fs;
 use std::path;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use integer_encoding::FixedIntWriter;
 
@@ -25,7 +25,7 @@ fn read_footer(f: &dyn RandomAccess, size: usize) -> Result<Footer> {
 /// `Table` is used for accessing SSTables.
 #[derive(Clone)]
 pub struct Table {
-    file: Rc<Box<dyn RandomAccess>>,
+    file: Arc<Box<dyn RandomAccess>>,
     file_size: usize,
     cache_id: cache::CacheID,
 
@@ -55,7 +55,7 @@ impl Table {
         let cache_id = opt.block_cache.borrow_mut().new_cache_id();
 
         Ok(Table {
-            file: Rc::new(file),
+            file: Arc::new(file),
             file_size: size,
             cache_id: cache_id,
             opt: opt,

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 
 use integer_encoding::FixedIntWriter;
 
+const LOCK_POISONED: &str = "Lock poisoned";
+
 /// Reads the table footer.
 fn read_footer(f: &dyn RandomAccess, size: usize) -> Result<Footer> {
     let mut buf = vec![0; table_builder::FULL_FOOTER_LENGTH];
@@ -52,7 +54,10 @@ impl Table {
             table_block::read_table_block(opt.clone(), file.as_ref(), &footer.meta_index)?;
 
         let filter_block_reader = Table::read_filter_block(&metaindex_block, file.as_ref(), &opt)?;
-        let cache_id = opt.block_cache.borrow_mut().new_cache_id();
+        let cache_id = {
+            let mut block_cache = opt.block_cache.write().expect(LOCK_POISONED);
+            block_cache.new_cache_id()
+        };
 
         Ok(Table {
             file: Arc::new(file),
@@ -108,7 +113,8 @@ impl Table {
     /// cache.
     fn read_block(&self, location: &BlockHandle) -> Result<Block> {
         let cachekey = self.block_cache_handle(location.offset());
-        if let Some(block) = self.opt.block_cache.borrow_mut().get(&cachekey) {
+        let mut block_cache = self.opt.block_cache.write().expect(LOCK_POISONED);
+        if let Some(block) = block_cache.get(&cachekey) {
             return Ok(block.clone());
         }
 
@@ -116,11 +122,8 @@ impl Table {
         let b =
             table_block::read_table_block(self.opt.clone(), self.file.as_ref().as_ref(), location)?;
 
-        // insert a cheap copy (Rc).
-        self.opt
-            .block_cache
-            .borrow_mut()
-            .insert(&cachekey, b.clone());
+        // insert a cheap copy (Arc).
+        block_cache.insert(&cachekey, b.clone());
 
         Ok(b)
     }
@@ -417,15 +420,17 @@ mod tests {
         let mut iter = table.iter();
 
         // index/metaindex blocks are not cached. That'd be a waste of memory.
-        assert_eq!(opt.block_cache.borrow().count(), 0);
+        assert_eq!(opt.block_cache.read().expect(LOCK_POISONED).count(), 0);
+    
         iter.next();
-        assert_eq!(opt.block_cache.borrow().count(), 1);
+        assert_eq!(opt.block_cache.read().expect(LOCK_POISONED).count(), 1);
+    
         // This may fail if block parameters or data change. In that case, adapt it.
         iter.next();
         iter.next();
         iter.next();
         iter.next();
-        assert_eq!(opt.block_cache.borrow().count(), 2);
+        assert_eq!(opt.block_cache.read().expect(LOCK_POISONED).count(), 2);
     }
 
     #[test]
@@ -613,7 +618,7 @@ mod tests {
             assert_eq!(Ok(Some(v)), r);
         }
 
-        assert_eq!(table.opt.block_cache.borrow().count(), 3);
+        assert_eq!(table.opt.block_cache.read().expect(LOCK_POISONED).count(), 3);
 
         // test that filters work and don't return anything at all.
         assert!(table.get(b"aaa").unwrap().is_none());

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -421,10 +421,10 @@ mod tests {
 
         // index/metaindex blocks are not cached. That'd be a waste of memory.
         assert_eq!(opt.block_cache.read().expect(LOCK_POISONED).count(), 0);
-    
+
         iter.next();
         assert_eq!(opt.block_cache.read().expect(LOCK_POISONED).count(), 1);
-    
+
         // This may fail if block parameters or data change. In that case, adapt it.
         iter.next();
         iter.next();
@@ -618,7 +618,10 @@ mod tests {
             assert_eq!(Ok(Some(v)), r);
         }
 
-        assert_eq!(table.opt.block_cache.read().expect(LOCK_POISONED).count(), 3);
+        assert_eq!(
+            table.opt.block_cache.read().expect(LOCK_POISONED).count(),
+            3
+        );
 
         // test that filters work and don't return anything at all.
         assert!(table.get(b"aaa").unwrap().is_none());

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,13 +2,13 @@
 
 use crate::error::Result;
 
-use std::cell::RefCell;
 use std::fs::File;
 #[cfg(unix)]
 use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
 use std::sync::Arc;
+use std::sync::RwLock;
 
 pub trait RandomAccess : Send {
     fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize>;
@@ -49,10 +49,10 @@ impl RandomAccess for File {
 }
 
 /// A shared thingy with interior mutability.
-pub type Shared<T> = Arc<RefCell<T>>;
+pub type Shared<T> = Arc<RwLock<T>>;
 
-pub fn share<T>(t: T) -> Arc<RefCell<T>> {
-    Arc::new(RefCell::new(t))
+pub fn share<T>(t: T) -> Arc<RwLock<T>> {
+    Arc::new(RwLock::new(t))
 }
 
 /// An extension of the standard `Iterator` trait that supporting some additional functionality.

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ use std::os::windows::fs::FileExt;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-pub trait RandomAccess : Send + Sync {
+pub trait RandomAccess: Send + Sync {
     fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize>;
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,9 +8,9 @@ use std::fs::File;
 use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
-use std::rc::Rc;
+use std::sync::Arc;
 
-pub trait RandomAccess {
+pub trait RandomAccess : Send {
     fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize>;
 }
 
@@ -49,10 +49,10 @@ impl RandomAccess for File {
 }
 
 /// A shared thingy with interior mutability.
-pub type Shared<T> = Rc<RefCell<T>>;
+pub type Shared<T> = Arc<RefCell<T>>;
 
-pub fn share<T>(t: T) -> Rc<RefCell<T>> {
-    Rc::new(RefCell::new(t))
+pub fn share<T>(t: T) -> Arc<RefCell<T>> {
+    Arc::new(RefCell::new(t))
 }
 
 /// An extension of the standard `Iterator` trait that supporting some additional functionality.

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,7 +10,7 @@ use std::os::windows::fs::FileExt;
 use std::sync::Arc;
 use std::sync::RwLock;
 
-pub trait RandomAccess : Send {
+pub trait RandomAccess : Send + Sync {
     fn read_at(&self, off: usize, dst: &mut [u8]) -> Result<usize>;
 }
 
@@ -48,7 +48,7 @@ impl RandomAccess for File {
     }
 }
 
-/// A shared thingy with interior mutability.
+/// A shared thingy with guarded by a lock.
 pub type Shared<T> = Arc<RwLock<T>>;
 
 pub fn share<T>(t: T) -> Arc<RwLock<T>> {


### PR DESCRIPTION
I plan to extend my application to use sstable in more places, but I need to make the read-only table available to multiple threads. I struggled to achieve this on the application side of my code, because sstable uses `Rc` in multiple places and this does not implement `Send`, which makes it difficult to guard it by `Arc` and mutexes. My experiment to implement `Send` for `Table` went a little bit overboard, ending in implementing also `Sync` and using mutexes inside the sstable code. 

I'm extremely unsure if this a good idea to introduce this into the core library because of the performance impact it might have. In the recently included benchmarks, I did not see any impact in reading-speed, though. I also thought about a different approach, where the library uses a non-thread-safe `Cache` per default (the current one), but allows to the calling code to provide a custom `Cache` implementation. This would allow the application to choose the guarantees it needs.

Another possible problematic change is that I need to force Rust to treat Send+Sync for `Cache` using unsafe code. From what I can tell, the sstable `Cache` full-fills the guaranties needed and the implementation is actual quite similar to the lru-crate, which also needs to [force-define Send+Sync](https://github.com/jeromefroe/lru-rs/blob/53f53f6e762405be5a73ca87becb25d308e9d34b/src/lib.rs#L870).

What do you think is the best way to proceed? I'm totally fine in discarding this PR because I know the possible impacts are quite large.