### PR TITLE
Add "current_key()" function to SSIterator.

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -297,6 +297,14 @@ impl SSIterator for BlockIter {
             false
         }
     }
+
+    fn current_key(&self) -> Option<&[u8]> {
+        if self.valid() {
+            Some(&self.key)
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/table_reader.rs
+++ b/src/table_reader.rs
@@ -335,6 +335,14 @@ impl SSIterator for TableIterator {
             false
         }
     }
+
+    fn current_key(&self) -> Option<&[u8]> {
+        if let Some(ref cb) = self.current_block {
+            cb.current_key()
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -48,6 +48,15 @@ impl<'a> SSIterator for TestSSIter<'a> {
             false
         }
     }
+
+    fn current_key(&self) -> Option<&[u8]> {
+        if self.init && self.ix < self.v.len() {
+            Some(self.v[self.ix].0)
+        } else {
+            None
+        }
+    }
+
     fn valid(&self) -> bool {
         self.init && self.ix < self.v.len()
     }
@@ -95,14 +104,18 @@ pub fn test_iterator_properties<It: SSIterator>(mut it: It) {
     assert!(it.advance());
     assert!(it.valid());
     let first = current_key_val(&it);
+    assert_eq!(first.as_ref().unwrap().0, it.current_key().unwrap());
     assert!(it.advance());
     let second = current_key_val(&it);
+    assert_eq!(second.as_ref().unwrap().0, it.current_key().unwrap());
     assert!(it.advance());
     let third = current_key_val(&it);
+    assert_eq!(third.as_ref().unwrap().0, it.current_key().unwrap());
     // fourth (last) element
     assert!(it.advance());
     assert!(it.valid());
     let fourth = current_key_val(&it);
+    assert_eq!(fourth.as_ref().unwrap().0, it.current_key().unwrap());
     // past end is invalid
     assert!(!it.advance());
     assert!(!it.valid());

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,6 +69,8 @@ pub trait SSIterator {
     fn advance(&mut self) -> bool;
     /// Return the current item (i.e. the item most recently returned by `next()`).
     fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool;
+    /// Return a reference to the key of the current item (i.e. the item most recently returned by `next()`).
+    fn current_key(&self) -> Option<&[u8]>;
     /// Seek the iterator to `key` or the next bigger key. If the seek is invalid (past last
     /// element, or before first element), the iterator is `reset()` and not valid.
     fn seek(&mut self, key: &[u8]);
@@ -123,6 +125,9 @@ impl SSIterator for Box<dyn SSIterator> {
     }
     fn current(&self, key: &mut Vec<u8>, val: &mut Vec<u8>) -> bool {
         self.as_ref().current(key, val)
+    }
+    fn current_key(&self) -> Option<&[u8]> {
+        self.as_ref().current_key()
     }
     fn seek(&mut self, key: &[u8]) {
         self.as_mut().seek(key)


### PR DESCRIPTION
In case someone is not interested in the actual value, but just wants to check that an entry exists, only access to the key is needed and it can save the time to not copy the (possible large) value. In addition, returning the key as a reference to an already existing field allows even more optimized access.