### PR TITLE
Allow to set the block cache size manually.

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -44,7 +44,8 @@ pub struct Options {
 
 impl Options {
     /// Returns Options with a custom block cache capacity.
-    /// The capacity is given as number of items in the cache.
+    /// The capacity is given as number of items in the cache
+    /// and the minimal allowed capacity is 1.
     pub fn with_cache_capacity(mut self, capacity: usize) -> Options {
         self.block_cache = share(Cache::new(capacity));
         self
@@ -65,3 +66,4 @@ impl Default for Options {
         }
     }
 }
+

--- a/src/options.rs
+++ b/src/options.rs
@@ -43,7 +43,7 @@ pub struct Options {
 }
 
 impl Options {
-    /// Returns Options with a custom block cache capacity.
+    /// Configure to use a custom block cache capacity.
     /// The capacity is given as number of items in the cache
     /// and the minimal allowed capacity is 1.
     pub fn with_cache_capacity(mut self, capacity: usize) -> Options {

--- a/src/options.rs
+++ b/src/options.rs
@@ -42,6 +42,15 @@ pub struct Options {
     pub filter_policy: filter::BoxedFilterPolicy,
 }
 
+impl Options {
+    /// Returns Options with a custom block cache capacity.
+    /// The capacity is given as number of items in the cache.
+    pub fn with_cache_capacity(mut self, capacity: usize) -> Options {
+        self.block_cache = share(Cache::new(capacity));
+        self
+    }
+}
+
 impl Default for Options {
     fn default() -> Options {
         Options {


### PR DESCRIPTION
I had issues with memory consumption when using the library because I used a quite large number of `Table` instances which each had their own block cache. This added up to a quite huge main memory consumption in an access scenario where I was mainly doing write-operations and did not need the block cache.

While the other configuration options are marked as public and can be tuned manually,
the `Cache` type is not public and therefore can't be constructed from outside the crate.
Therefore, I can't set the `block_cache` field of `Options` even if the field is public.

This PR adds a "with_cache_capacity" function which allows changing the options
to use a block cache with a custom size.
