### PR TITLE
feat(SSIterator): add iterator impl for ssiterator trait

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -143,6 +143,15 @@ impl SSIterator for Box<dyn SSIterator> {
     }
 }
 
+// Allow interface to iterator.
+impl Iterator for dyn SSIterator {
+    type Item = (Vec<u8>, Vec<u8>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next()
+    }
+}
+
 const MASK_DELTA: u32 = 0xa282ead8;
 
 pub fn mask_crc(c: u32) -> u32 {


### PR DESCRIPTION
To be able to easily merge sstables, you can use the itertools::merge function for a quick mergesort of different sstables or memtables/sstables: 
https://docs.rs/itertools/0.7.8/itertools/trait.Itertools.html#method.merge

This PR implements the Iterator trait.

Example of using the SSIterator as an actual rust iterator enabled by this pr:
```
let st: Box<dyn SSIterator> = Box::new(sstable.iter());
for r in st {
    println!("hi");
}
```

Note that Sized is not implemented in this PR so you'll need to box the iter to use it as an Iterator.
Previously attempting to use SSIterator as an actual iterator would fail:

```
error[E0277]: `dyn sstable::SSIterator` is not an iterator
   --> src/citygraph/idsstable.rs:91:18
    |
91  |         for r in st {
    |                  ^^ `dyn sstable::SSIterator` is not an iterator
```

So we should be able to do something like this:

```
let new_kvs: (Type1, Type2) = sstable1.iter().merge(sstable2.iter()).collect();
```